### PR TITLE
fix: correct activePage variable name in Sidebar component

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -112,7 +112,7 @@ export default function Sidebar({
         <div className="relative w-72 max-w-[80vw] bg-white flex flex-col h-full shadow-2xl z-50 animate-in slide-in-from-left duration-300">
           <SidebarContent
             items={items}
-            active={activePage}
+            active={active}
             onNav={onNav}
             rates={rates}
             onClose={onClose}


### PR DESCRIPTION
Fixes the "activePage is not defined" runtime error in the sidebar navigation.