### PR TITLE
feat(US-3.1): CSV export for group dashboard and payout report

### DIFF
--- a/src/app/(dashboard)/groups/[groupId]/page.tsx
+++ b/src/app/(dashboard)/groups/[groupId]/page.tsx
@@ -16,6 +16,8 @@ import { db } from "@/lib/firebase";
 import { useFirebaseAuth } from "@/context/FirebaseAuthContext";
 import Link from "next/link";
 import ContributionForm from "@/components/forms/ContributionForm";
+import { toCSV } from "@/lib/utils/csv";
+import { downloadCSV, isoDate } from "@/lib/utils/download";
 
 interface Member {
   id: string;
@@ -67,6 +69,18 @@ function formatDate(value: Timestamp | string | null | undefined): string {
   return "—";
 }
 
+function toIsoDate(value: Timestamp | string | null | undefined): string {
+  if (!value) return "";
+  if (typeof value === "string") {
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? "" : isoDate(d);
+  }
+  if (typeof (value as Timestamp).toDate === "function") {
+    return isoDate((value as Timestamp).toDate());
+  }
+  return "";
+}
+
 export default function GroupDashboardPage() {
   const { groupId } = useParams<{ groupId: string }>();
   const { user } = useFirebaseAuth();
@@ -77,6 +91,7 @@ export default function GroupDashboardPage() {
   const [loading, setLoading] = useState(true);
   const [isAdmin, setIsAdmin] = useState(false);
   const [isMember, setIsMember] = useState(false);
+  const [exportMenuOpen, setExportMenuOpen] = useState(false);
 
   useEffect(() => {
     if (!groupId || !user) return;
@@ -153,6 +168,59 @@ export default function GroupDashboardPage() {
   const groupName = group?.group_name || group?.name || "Group";
   const contributionAmount = group?.contribution_amount;
   const expectedTotalPerCycle = contributionAmount ? contributionAmount * members.length : null;
+  const avgPerMember = members.length > 0 ? contributions.total / members.length : null;
+
+  const exportSummary = () => {
+    const csv = toCSV(
+      [
+        {
+          name: groupName,
+          id: groupId,
+          memberCount: members.length,
+          contributionAmount: contributionAmount ?? null,
+          totalContributed: contributions.total,
+          paymentCount: contributions.count,
+          expectedPerCycle: expectedTotalPerCycle,
+          payoutFrequency: group?.payout_frequency ?? "",
+          payoutOrder: group?.payout_order ?? "",
+          avgPerMember,
+          createdBy: group?.created_by_name ?? "",
+          createdAt: toIsoDate(group?.created_at),
+        },
+      ],
+      [
+        { header: "Group Name", accessor: (r) => r.name },
+        { header: "Group ID", accessor: (r) => r.id },
+        { header: "Members", accessor: (r) => r.memberCount },
+        { header: "Contribution/Cycle (ZAR)", accessor: (r) => r.contributionAmount },
+        { header: "Total Contributed (ZAR)", accessor: (r) => r.totalContributed },
+        { header: "Payment Count", accessor: (r) => r.paymentCount },
+        { header: "Expected/Cycle (ZAR)", accessor: (r) => r.expectedPerCycle },
+        { header: "Payout Frequency", accessor: (r) => r.payoutFrequency },
+        { header: "Payout Order", accessor: (r) => r.payoutOrder },
+        { header: "Avg/Member (ZAR)", accessor: (r) => r.avgPerMember },
+        { header: "Created By", accessor: (r) => r.createdBy },
+        { header: "Created At", accessor: (r) => r.createdAt },
+      ]
+    );
+    downloadCSV(`group-summary-${groupId}-${isoDate()}.csv`, csv);
+    setExportMenuOpen(false);
+  };
+
+  const exportMembers = () => {
+    const csv = toCSV(
+      members,
+      [
+        { header: "Name/Email", accessor: (m) => m.displayName || m.email || m.userId },
+        { header: "Role", accessor: (m) => m.role },
+        { header: "Joined At", accessor: (m) => toIsoDate(m.joinedAt) },
+        { header: "User ID", accessor: (m) => m.userId },
+        { header: "Contributed (ZAR)", accessor: (m) => contributions.byMember[m.userId] ?? 0 },
+      ]
+    );
+    downloadCSV(`members-${groupId}-${isoDate()}.csv`, csv);
+    setExportMenuOpen(false);
+  };
 
   return (
     <div className="p-6 max-w-5xl mx-auto">
@@ -179,6 +247,49 @@ export default function GroupDashboardPage() {
           >
             Meetings
           </Link>
+          {isAdmin && (
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setExportMenuOpen((o) => !o)}
+                className="inline-flex items-center gap-2 bg-white border border-gray-200 hover:border-emerald-500 hover:text-emerald-700 text-gray-700 font-semibold py-2 px-5 rounded-xl transition-all"
+                aria-haspopup="menu"
+                aria-expanded={exportMenuOpen}
+              >
+                Export CSV
+              </button>
+              {exportMenuOpen && (
+                <>
+                  <div
+                    className="fixed inset-0 z-10"
+                    onClick={() => setExportMenuOpen(false)}
+                    aria-hidden="true"
+                  />
+                  <div
+                    role="menu"
+                    className="absolute right-0 mt-2 w-56 bg-white border border-gray-200 rounded-xl shadow-lg z-20 overflow-hidden"
+                  >
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={exportSummary}
+                      className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-emerald-50 hover:text-emerald-700"
+                    >
+                      Group summary
+                    </button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={exportMembers}
+                      className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-emerald-50 hover:text-emerald-700"
+                    >
+                      Members
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
           {isAdmin && (
             <Link
               href={`/groups/${groupId}/invite`}

--- a/src/components/analytics/PayoutReport.tsx
+++ b/src/components/analytics/PayoutReport.tsx
@@ -1,8 +1,10 @@
 ﻿"use client";
 
 import { useEffect, useState } from "react";
-import { getPayoutReportData, PayoutReportData } from "@/services/analytics.service";
+import { getPayoutReportData, PayoutReportData, PayoutRecord, PayoutProjection } from "@/services/analytics.service";
 import PayoutTimelineChart from "./PayoutTimelineChart";
+import { toCSV } from "@/lib/utils/csv";
+import { downloadCSV, isoDate } from "@/lib/utils/download";
 
 interface PayoutReportProps {
   groupId: string;
@@ -60,6 +62,33 @@ export default function PayoutReport({ groupId }: PayoutReportProps) {
     return <div className="p-8 text-center text-gray-500">No payout data available</div>;
   }
 
+  const toIso = (s: string) => {
+    if (!s || s === "TBD") return "";
+    const d = new Date(s);
+    return isNaN(d.getTime()) ? "" : isoDate(d);
+  };
+
+  const exportPastPayouts = () => {
+    const csv = toCSV<PayoutRecord>(data.pastPayouts, [
+      { header: "Date", accessor: (r) => toIso(r.payoutDate) },
+      { header: "Member", accessor: (r) => r.memberName },
+      { header: "Amount (ZAR)", accessor: (r) => r.amount },
+      { header: "Status", accessor: (r) => r.status },
+    ]);
+    downloadCSV(`past-payouts-${groupId}-${isoDate()}.csv`, csv);
+  };
+
+  const exportUpcoming = () => {
+    const csv = toCSV<PayoutProjection>(data.upcomingProjections, [
+      { header: "Position", accessor: (r) => r.position },
+      { header: "Member", accessor: (r) => r.memberName },
+      { header: "Expected Date", accessor: (r) => toIso(r.expectedDate) },
+      { header: "Amount (ZAR)", accessor: (r) => r.amount },
+      { header: "Status", accessor: (r) => r.status },
+    ]);
+    downloadCSV(`upcoming-payouts-${groupId}-${isoDate()}.csv`, csv);
+  };
+
   return (
     <div className="space-y-8">
       {/* Summary Cards */}
@@ -86,9 +115,18 @@ export default function PayoutReport({ groupId }: PayoutReportProps) {
 
       {/* Past Payouts Table */}
       <div className="bg-white rounded-lg shadow overflow-hidden">
-        <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
-          <h2 className="text-lg font-bold text-gray-900">📋 Past Payouts</h2>
-          <p className="text-sm text-gray-500">Completed payouts with dates and amounts (detailed list)</p>
+        <div className="px-6 py-4 bg-gray-50 border-b border-gray-200 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-bold text-gray-900">📋 Past Payouts</h2>
+            <p className="text-sm text-gray-500">Completed payouts with dates and amounts (detailed list)</p>
+          </div>
+          <button
+            type="button"
+            onClick={exportPastPayouts}
+            className="px-3 py-1.5 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 text-sm font-semibold whitespace-nowrap"
+          >
+            Export CSV
+          </button>
         </div>
         <div className="p-6">
           {!data.hasPastPayouts ? (
@@ -128,9 +166,18 @@ export default function PayoutReport({ groupId }: PayoutReportProps) {
 
       {/* Upcoming Projections Table */}
       <div className="bg-white rounded-lg shadow overflow-hidden">
-        <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
-          <h2 className="text-lg font-bold text-gray-900">📅 Upcoming Projected Payouts</h2>
-          <p className="text-sm text-gray-500">Future payouts based on current schedule (detailed list)</p>
+        <div className="px-6 py-4 bg-gray-50 border-b border-gray-200 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-bold text-gray-900">📅 Upcoming Projected Payouts</h2>
+            <p className="text-sm text-gray-500">Future payouts based on current schedule (detailed list)</p>
+          </div>
+          <button
+            type="button"
+            onClick={exportUpcoming}
+            className="px-3 py-1.5 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 text-sm font-semibold whitespace-nowrap"
+          >
+            Export CSV
+          </button>
         </div>
         <div className="p-6">
           {data.upcomingProjections.length === 0 ? (

--- a/src/lib/utils/csv.ts
+++ b/src/lib/utils/csv.ts
@@ -1,0 +1,21 @@
+export interface CSVColumn<T> {
+  header: string;
+  accessor: (row: T) => string | number | null | undefined;
+}
+
+function escapeCell(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  if (/[",\r\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export function toCSV<T>(rows: T[], columns: CSVColumn<T>[]): string {
+  const headerLine = columns.map((c) => escapeCell(c.header)).join(",");
+  const dataLines = rows.map((row) =>
+    columns.map((c) => escapeCell(c.accessor(row))).join(",")
+  );
+  return [headerLine, ...dataLines].join("\r\n");
+}

--- a/src/lib/utils/download.ts
+++ b/src/lib/utils/download.ts
@@ -1,0 +1,18 @@
+export function downloadCSV(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function isoDate(d: Date = new Date()): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}

--- a/tests/unit/csv.test.ts
+++ b/tests/unit/csv.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { toCSV, CSVColumn } from "@/lib/utils/csv";
+
+interface Row {
+  name: string;
+  amount: number | null;
+  note?: string | null;
+}
+
+const columns: CSVColumn<Row>[] = [
+  { header: "Name", accessor: (r) => r.name },
+  { header: "Amount", accessor: (r) => r.amount },
+  { header: "Note", accessor: (r) => r.note },
+];
+
+describe("toCSV", () => {
+  it("emits header row and data rows with correct columns", () => {
+    const csv = toCSV<Row>(
+      [
+        { name: "Alice", amount: 500, note: "ok" },
+        { name: "Bob", amount: 1500, note: "vip" },
+      ],
+      columns
+    );
+    expect(csv).toBe(
+      "Name,Amount,Note\r\nAlice,500,ok\r\nBob,1500,vip"
+    );
+  });
+
+  it("emits header-only output when rows are empty (UAT 3)", () => {
+    const csv = toCSV<Row>([], columns);
+    expect(csv).toBe("Name,Amount,Note");
+    expect(csv.split("\r\n")).toHaveLength(1);
+  });
+
+  it("escapes commas, quotes, and newlines per RFC 4180", () => {
+    const csv = toCSV<Row>(
+      [
+        { name: "Doe, John", amount: 100, note: 'He said "hi"' },
+        { name: "Line\nBreak", amount: 200, note: "carriage\rreturn" },
+      ],
+      columns
+    );
+    const lines = csv.split("\r\n");
+    expect(lines[0]).toBe("Name,Amount,Note");
+    expect(lines[1]).toBe('"Doe, John",100,"He said ""hi"""');
+    expect(lines[2]).toBe('"Line\nBreak",200,"carriage\rreturn"');
+  });
+
+  it("renders null and undefined cells as empty strings", () => {
+    const csv = toCSV<Row>(
+      [{ name: "Eve", amount: null, note: undefined }],
+      columns
+    );
+    expect(csv).toBe("Name,Amount,Note\r\nEve,,");
+  });
+});


### PR DESCRIPTION
Adds a generic client-side CSV utility (RFC 4180 escaping, header-only output on empty data) and wires Export CSV controls into the admin group dashboard (Summary + Members) and the payout report (Past + Upcoming).

## What does this PR do?
Adds CSV export so Admins can pull dashboard data into spreadsheets or share it with off-platform members (US-3.1).

## Related Issue
Closes #13 

## Type of Change
- [x] New feature (user story)
- [ ] Bug fix
- [ ] Tech task / infrastructure
- [ ] Refactor (no behaviour change)

## Checklist
- [x] My code follows the project style guidelines
- [x] I have added comments to explain complex logic
- [x] I have written/updated unit tests
- [x] All tests pass locally
- [x] I have tested this feature manually
- [x] I have updated the relevant documentation (if applicable)
